### PR TITLE
Fix documentation consistency issues in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A curated collection of high-quality `CLAUDE.md` files from leading open-source 
 ## 🔍 Browse by Technology
 
 <details>
-<summary><strong>🟦 TypeScript/JavaScript</strong> (23 examples)</summary>
+<summary><strong>🟦 TypeScript/JavaScript</strong> (22 examples)</summary>
 
 - **[H1B Visa Analysis](scenarios/complex-projects/ChaseNoCap_h1b-visa-analysis/README.md)** ![Stars](https://img.shields.io/github/stars/ChaseNoCap/h1b-visa-analysis?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/ChaseNoCap/h1b-visa-analysis?style=flat-square) - AI-guided meta-repository framework
 - **[SDLC Engine](scenarios/developer-tooling/ChaseNoCap_sdlc-engine/README.md)** ![Stars](https://img.shields.io/github/stars/ChaseNoCap/sdlc-engine?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/ChaseNoCap/sdlc-engine?style=flat-square) - State machine workflow orchestration
@@ -70,8 +70,8 @@ A curated collection of high-quality `CLAUDE.md` files from leading open-source 
 - **[Claude Crew](scenarios/developer-tooling/d-kimuson_claude-crew/README.md)** ![Stars](https://img.shields.io/github/stars/d-kimuson/claude-crew?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/d-kimuson/claude-crew?style=flat-square) - Strict TypeScript standards
 - **[Web Builder](scenarios/complex-projects/dev-mahfuj80_web-builder/README.md)** ![Stars](https://img.shields.io/github/stars/dev-mahfuj80/web-builder?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/dev-mahfuj80/web-builder?style=flat-square) - B2B2B SaaS platform with Next.js 14
 - **[mdx-prompt](scenarios/libraries-frameworks/edspencer_mdx-prompt/README.md)** ![Stars](https://img.shields.io/github/stars/edspencer/mdx-prompt?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/edspencer/mdx-prompt?style=flat-square) - LLM prompt components
-- **[MCP WordPress](scenarios/developer-tooling/docdyhr_mcp-wordpress/README.md)** ![Stars](https://img.shields.io/github/stars/docdyhr/mcp-wordpress?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/docdyhr/mcp-wordpress?style=flat-square) - MCP server for WordPress CMS
-- **[GalaChain SDK](scenarios/libraries-frameworks/GalaChain_sdk/README.md)** ![Stars](https://img.shields.io/github/stars/GalaChain/sdk?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/GalaChain/sdk?style=flat-square) - Blockchain SDK with TypeScript
+- **[MCP WordPress](scenarios/developer-tooling/docdyhr_mcp-wordpress/analysis.md)** ![Stars](https://img.shields.io/github/stars/docdyhr/mcp-wordpress?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/docdyhr/mcp-wordpress?style=flat-square) - MCP server for WordPress CMS
+- **[GalaChain SDK](scenarios/libraries-frameworks/GalaChain_sdk/analysis.md)** ![Stars](https://img.shields.io/github/stars/GalaChain/sdk?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/GalaChain/sdk?style=flat-square) - Blockchain SDK with TypeScript
 - **[Overreacted.io](scenarios/complex-projects/gaearon_overreacted.io/README.md)** ![Stars](https://img.shields.io/github/stars/gaearon/overreacted.io?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/gaearon/overreacted.io?style=flat-square) - Next.js with MDX
 - **[Image Generation MCP](scenarios/developer-tooling/johnw188_image-generation-mcp/README.md)** ![Stars](https://img.shields.io/github/stars/johnw188/image-generation-mcp?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/johnw188/image-generation-mcp?style=flat-square) - MCP server with Cloudflare Workers
 - **[KleverConnect Starter](scenarios/getting-started/klever-hub_kleverconnect-starter/README.md)** ![Stars](https://img.shields.io/github/stars/klever-hub/kleverconnect-starter?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/klever-hub/kleverconnect-starter?style=flat-square) - Web3 React + Vite
@@ -112,7 +112,7 @@ A curated collection of high-quality `CLAUDE.md` files from leading open-source 
 </details>
 
 <details>
-<summary><strong>🟫 Rust</strong> (7 examples)</summary>
+<summary><strong>🟫 Rust</strong> (6 examples)</summary>
 
 - **[Workerd](scenarios/infrastructure-projects/cloudflare_workerd/README.md)** ![Stars](https://img.shields.io/github/stars/cloudflare/workerd?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/cloudflare/workerd?style=flat-square) - JavaScript runtime for Cloudflare Workers
 - **[OAuth2 Passkey](scenarios/libraries-frameworks/ktaka-ccmp_oauth2-passkey/README.md)** ![Stars](https://img.shields.io/github/stars/ktaka-ccmp/oauth2-passkey?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/ktaka-ccmp/oauth2-passkey?style=flat-square) - Modern authentication library
@@ -120,7 +120,6 @@ A curated collection of high-quality `CLAUDE.md` files from leading open-source 
 - **[PyTorch tlparse](scenarios/developer-tooling/pytorch_tlparse/README.md)** ![Stars](https://img.shields.io/github/stars/pytorch/tlparse?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/pytorch/tlparse?style=flat-square) - Log parsing with Python bindings
 - **[SVGC](scenarios/developer-tooling/okuvshynov_svgc/README.md)** ![Stars](https://img.shields.io/github/stars/okuvshynov/svgc?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/okuvshynov/svgc?style=flat-square) - SVG optimization tool
 - **[Tasker Core](scenarios/developer-tooling/tasker-systems_tasker-core-rs/README.md)** ![Stars](https://img.shields.io/github/stars/tasker-systems/tasker-core-rs?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/tasker-systems/tasker-core-rs?style=flat-square) - Workflow orchestration engine
-- **[TimeWarp Architecture](scenarios/complex-projects/TimeWarpEngineering_timewarp-architecture/README.md)** ![Stars](https://img.shields.io/github/stars/TimeWarpEngineering/timewarp-architecture?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/TimeWarpEngineering/timewarp-architecture?style=flat-square) - Blazor WebAssembly framework
 
 </details>
 
@@ -141,7 +140,7 @@ A curated collection of high-quality `CLAUDE.md` files from leading open-source 
 </details>
 
 <details>
-<summary><strong>🟨 Other Languages</strong> (7 examples)</summary>
+<summary><strong>🟨 Other Languages</strong> (8 examples)</summary>
 
 - **[Kotlinter Gradle](scenarios/developer-tooling/jeremymailen_kotlinter-gradle/README.md)** ![Stars](https://img.shields.io/github/stars/jeremymailen/kotlinter-gradle?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/jeremymailen/kotlinter-gradle?style=flat-square) - Kotlin linting plugin
 - **[HWP](scenarios/developer-tooling/mcollina_hwp/README.md)** ![Stars](https://img.shields.io/github/stars/mcollina/hwp?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/mcollina/hwp?style=flat-square) - Node.js HTTP benchmarking
@@ -149,6 +148,7 @@ A curated collection of high-quality `CLAUDE.md` files from leading open-source 
 - **[Pipewire-HS](scenarios/libraries-frameworks/JonathanLorimer_pipewire-hs/README.md)** ![Stars](https://img.shields.io/github/stars/JonathanLorimer/pipewire-hs?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/JonathanLorimer/pipewire-hs?style=flat-square) - Haskell bindings for PipeWire
 - **[mypy-boto3-builder](scenarios/developer-tooling/youtype_mypy-boto3-builder/README.md)** ![Stars](https://img.shields.io/github/stars/youtype/mypy-boto3-builder?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/youtype/mypy-boto3-builder?style=flat-square) - AWS SDK type stubs generator
 - **[WindPress](scenarios/complex-projects/wind-press_windpress/analysis.md)** ![Stars](https://img.shields.io/github/stars/wind-press/windpress?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/wind-press/windpress?style=flat-square) - Vue.js with WebAssembly Tailwind compilation
+- **[TimeWarp Architecture](scenarios/complex-projects/TimeWarpEngineering_timewarp-architecture/README.md)** ![Stars](https://img.shields.io/github/stars/TimeWarpEngineering/timewarp-architecture?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/TimeWarpEngineering/timewarp-architecture?style=flat-square) - C#/.NET Blazor WebAssembly framework
 - **[Tasker Systems Book](scenarios/project-handoffs/tasker-systems_book/analysis.md)** ![Stars](https://img.shields.io/github/stars/tasker-systems/book?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/tasker-systems/book?style=flat-square) - Narrative-driven technical documentation
 
 </details>
@@ -186,7 +186,7 @@ A curated collection of high-quality `CLAUDE.md` files from leading open-source 
 <details>
 <summary><strong>🌐 Web3 & Blockchain</strong> (3 examples)</summary>
 
-- **[GalaChain SDK](scenarios/libraries-frameworks/GalaChain_sdk/README.md)** ![Stars](https://img.shields.io/github/stars/GalaChain/sdk?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/GalaChain/sdk?style=flat-square) - Blockchain SDK for chaincode development
+- **[GalaChain SDK](scenarios/libraries-frameworks/GalaChain_sdk/analysis.md)** ![Stars](https://img.shields.io/github/stars/GalaChain/sdk?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/GalaChain/sdk?style=flat-square) - Blockchain SDK for chaincode development
 - **[KleverConnect Starter](scenarios/getting-started/klever-hub_kleverconnect-starter/README.md)** ![Stars](https://img.shields.io/github/stars/klever-hub/kleverconnect-starter?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/klever-hub/kleverconnect-starter?style=flat-square) - Web3 React + Vite starter kit
 - **[Ethereum.org Website](scenarios/getting-started/ethereum_ethereum-org-website/README.md)** ![Stars](https://img.shields.io/github/stars/ethereum/ethereum-org-website?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/ethereum/ethereum-org-website?style=flat-square) - Official Ethereum community website
 
@@ -294,7 +294,7 @@ Multi-service applications with sophisticated architectures and enterprise-scale
 ### 🛠️ Developer Tooling
 CLI tools, build systems, and development utilities with focus on commands and configuration.
 
-- **[MCP WordPress](scenarios/developer-tooling/docdyhr_mcp-wordpress/README.md)** ![Stars](https://img.shields.io/github/stars/docdyhr/mcp-wordpress?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/docdyhr/mcp-wordpress?style=flat-square) ![Activity](https://img.shields.io/github/last-commit/docdyhr/mcp-wordpress?style=flat-square) - MCP server for WordPress CMS integration
+- **[MCP WordPress](scenarios/developer-tooling/docdyhr_mcp-wordpress/analysis.md)** ![Stars](https://img.shields.io/github/stars/docdyhr/mcp-wordpress?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/docdyhr/mcp-wordpress?style=flat-square) ![Activity](https://img.shields.io/github/last-commit/docdyhr/mcp-wordpress?style=flat-square) - MCP server for WordPress CMS integration
   - Model Context Protocol server development
   - Multi-site WordPress management patterns
   - Security-first architecture with data sanitization
@@ -448,7 +448,7 @@ Large-scale systems, runtime environments, and platform-agnostic deployment patt
 ### 📚 Libraries & Frameworks
 Core concepts, APIs, usage patterns, and publication-ready development standards.
 
-- **[GalaChain SDK](scenarios/libraries-frameworks/GalaChain_sdk/README.md)** ![Stars](https://img.shields.io/github/stars/GalaChain/sdk?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/GalaChain/sdk?style=flat-square) ![Activity](https://img.shields.io/github/last-commit/GalaChain/sdk?style=flat-square) - Blockchain SDK for TypeScript development
+- **[GalaChain SDK](scenarios/libraries-frameworks/GalaChain_sdk/analysis.md)** ![Stars](https://img.shields.io/github/stars/GalaChain/sdk?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/GalaChain/sdk?style=flat-square) ![Activity](https://img.shields.io/github/last-commit/GalaChain/sdk?style=flat-square) - Blockchain SDK for TypeScript development
   - Chaincode development patterns with TypeScript
   - Multi-level testing strategy (unit, integration, e2e)
   - Modular SDK architecture for blockchain applications
@@ -601,6 +601,6 @@ Find more `CLAUDE.md` examples using these search strategies:
 
 ---
 
-**Total Examples**: 57 | **Last Updated**: August 2025 | **Maintained by**: Community Contributors
+**Total Examples**: 61 | **Last Updated**: August 2025 | **Maintained by**: Community Contributors
 
 > 🤖 This collection is maintained with assistance from Claude Code for quality analysis and curation


### PR DESCRIPTION
## Summary
- Fixed total count mismatch (was showing 57, actual is 61)
- Corrected TypeScript count from 23 to 22
- Fixed Rust count from 7 to 6
- Updated Other Languages count from 7 to 8
- Fixed multiple broken internal links (changed README.md references to analysis.md)
- Corrected TimeWarp Architecture categorization from Rust to Other Languages

## Changes Made
- Updated all category counts to match actual number of examples
- Fixed broken links for newly added examples
- Moved TimeWarp Architecture to correct language category (C#/.NET)

## Context
These fixes were identified after adding examples from issues #32 and #34. The project-docs-curator agent helped identify these inconsistencies.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>