### PR TITLE
feat: add 8 new examples from discovery issues #46-#78

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A curated collection of high-quality `CLAUDE.md` files from leading open-source 
 ## 🔍 Browse by Technology
 
 <details>
-<summary><strong>🟦 TypeScript/JavaScript</strong> (36 examples)</summary>
+<summary><strong>🟦 TypeScript/JavaScript</strong> (37 examples)</summary>
 
 - **[Callstack React Native Testing](scenarios/libraries-frameworks/callstack_react-native-testing-library/analysis.md)** ![Stars](https://img.shields.io/github/stars/callstack/react-native-testing-library?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/callstack/react-native-testing-library?style=flat-square) - Testing library gold standard from React Native experts
 - **[Citadel Protocol Contracts](scenarios/complex-projects/Citadel-Protocol_contracts/analysis.md)** ![Stars](https://img.shields.io/github/stars/Citadel-Protocol/contracts?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/Citadel-Protocol/contracts?style=flat-square) - Security-first DeFi protocol documentation
@@ -107,10 +107,11 @@ A curated collection of high-quality `CLAUDE.md` files from leading open-source 
 </details>
 
 <details>
-<summary><strong>🟧 Python</strong> (22 examples)</summary>
+<summary><strong>🟧 Python</strong> (24 examples)</summary>
 
 - **[Anthropic Quickstarts](scenarios/getting-started/anthropics_anthropic-quickstarts/README.md)** ![Stars](https://img.shields.io/github/stars/anthropics/anthropic-quickstarts?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/anthropics/anthropic-quickstarts?style=flat-square) - Computer-use demo
 - **[Basic Memory](scenarios/complex-projects/basicmachines-co_basic-memory/README.md)** ![Stars](https://img.shields.io/github/stars/basicmachines-co/basic-memory?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/basicmachines-co/basic-memory?style=flat-square) - MCP integration
+- **[BEDROT Data Ecosystem](scenarios/complex-projects/blakedemarest_bedrot-data-ecosystem/README.md)** ![Stars](https://img.shields.io/github/stars/blakedemarest/bedrot-data-ecosystem?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/blakedemarest/bedrot-data-ecosystem?style=flat-square) - Music industry analytics data pipeline
 - **[Composio](scenarios/libraries-frameworks/ComposioHQ_composio/README.md)** ![Stars](https://img.shields.io/github/stars/ComposioHQ/composio?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/ComposioHQ/composio?style=flat-square) - AI agent integration platform
 - **[DataFog Python](scenarios/libraries-frameworks/DataFog_datafog-python/README.md)** ![Stars](https://img.shields.io/github/stars/DataFog/datafog-python?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/DataFog/datafog-python?style=flat-square) - Privacy-focused data processing
 - **[Swift Law](scenarios/developer-tooling/etisamhaq_Swift-Law/README.md)** ![Stars](https://img.shields.io/github/stars/etisamhaq/Swift-Law?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/etisamhaq/Swift-Law?style=flat-square) - Legal AI assistant
@@ -130,15 +131,17 @@ A curated collection of high-quality `CLAUDE.md` files from leading open-source 
 - **[Pydantic GenAI Prices](scenarios/libraries-frameworks/pydantic_genai-prices/README.md)** ![Stars](https://img.shields.io/github/stars/pydantic/genai-prices?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/pydantic/genai-prices?style=flat-square) - Expert data processing pipeline
 - **[PyTorch tlparse](scenarios/developer-tooling/pytorch_tlparse/README.md)** ![Stars](https://img.shields.io/github/stars/pytorch/tlparse?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/pytorch/tlparse?style=flat-square) - Dual-language (Rust/Python)
 - **[Demo MCP](scenarios/infrastructure-projects/sedwardstx_demomcp/analysis.md)** ![Stars](https://img.shields.io/github/stars/sedwardstx/demomcp?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/sedwardstx/demomcp?style=flat-square) - MCP server architecture patterns
+- **[viral-assemble](scenarios/libraries-frameworks/broadinstitute_viral-assemble/README.md)** ![Stars](https://img.shields.io/github/stars/broadinstitute/viral-assemble?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/broadinstitute/viral-assemble?style=flat-square) - Viral genome assembly toolkit from Broad Institute
 - **[Weaviate Docs](scenarios/getting-started/weaviate_docs/README.md)** ![Stars](https://img.shields.io/github/stars/weaviate/docs?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/weaviate/docs?style=flat-square) - Documentation for Weaviate Database
 
 </details>
 
 <details>
-<summary><strong>🟫 Rust</strong> (9 examples)</summary>
+<summary><strong>🟫 Rust</strong> (10 examples)</summary>
 
 - **[Breenix OS](scenarios/infrastructure-projects/ryanbreen_breenix/README.md)** ![Stars](https://img.shields.io/github/stars/ryanbreen/breenix?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/ryanbreen/breenix?style=flat-square) - Rust kernel development with rigorous engineering standards
 - **[cctx](scenarios/developer-tooling/nwiizo_cctx/README.md)** ![Stars](https://img.shields.io/github/stars/nwiizo/cctx?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/nwiizo/cctx?style=flat-square) - Claude Code context manager with UX philosophy documentation
+- **[Cribo](scenarios/developer-tooling/ophidiarium_cribo/README.md)** ![Stars](https://img.shields.io/github/stars/ophidiarium/cribo?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/ophidiarium/cribo?style=flat-square) - Python source bundler with exhaustive AI agent directives
 - **[Workerd](scenarios/infrastructure-projects/cloudflare_workerd/README.md)** ![Stars](https://img.shields.io/github/stars/cloudflare/workerd?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/cloudflare/workerd?style=flat-square) - JavaScript runtime for Cloudflare Workers
 - **[msg-rs](scenarios/libraries-frameworks/chainbound_msg-rs/analysis.md)** ![Stars](https://img.shields.io/github/stars/chainbound/msg-rs?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/chainbound/msg-rs?style=flat-square) - Distributed systems messaging library
 - **[OAuth2 Passkey](scenarios/libraries-frameworks/ktaka-ccmp_oauth2-passkey/README.md)** ![Stars](https://img.shields.io/github/stars/ktaka-ccmp/oauth2-passkey?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/ktaka-ccmp/oauth2-passkey?style=flat-square) - Modern authentication library
@@ -157,10 +160,12 @@ A curated collection of high-quality `CLAUDE.md` files from leading open-source 
 </details>
 
 <details>
-<summary><strong>🟢 Go</strong> (3 examples)</summary>
+<summary><strong>🟢 Go</strong> (5 examples)</summary>
 
 - **[Claudio](scenarios/developer-tooling/ctoth_claudio/README.md)** ![Stars](https://img.shields.io/github/stars/ctoth/claudio?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/ctoth/claudio?style=flat-square) - Audio feedback plugin with TDD methodology
+- **[Dymension Hub](scenarios/infrastructure-projects/dymensionxyz_dymension/README.md)** ![Stars](https://img.shields.io/github/stars/dymensionxyz/dymension?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/dymensionxyz/dymension?style=flat-square) - Cosmos SDK settlement layer with modular rollup architecture
 - **[GoMall](scenarios/developer-tooling/li0on3_GoMall/README.md)** ![Stars](https://img.shields.io/github/stars/li0on3/GoMall?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/li0on3/GoMall?style=flat-square) - RIPER-5 AI methodology
+- **[ReGo](scenarios/libraries-frameworks/gemini-oss_rego/README.md)** ![Stars](https://img.shields.io/github/stars/gemini-oss/rego?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/gemini-oss/rego?style=flat-square) - Unified REST API abstraction layer for enterprise services
 - **[Sentry](scenarios/complex-projects/getsentry_sentry/README.md)** ![Stars](https://img.shields.io/github/stars/getsentry/sentry?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/getsentry/sentry?style=flat-square) - Multi-language error tracking platform
 
 </details>
@@ -176,9 +181,10 @@ A curated collection of high-quality `CLAUDE.md` files from leading open-source 
 </details>
 
 <details>
-<summary><strong>🟨 Other Languages</strong> (10 examples)</summary>
+<summary><strong>🟨 Other Languages</strong> (13 examples)</summary>
 
 **Elixir**
+- **[mehr-schulferien.de](scenarios/complex-projects/mehr-schulferien-de_www.mehr-schulferien.de/README.md)** ![Stars](https://img.shields.io/github/stars/mehr-schulferien-de/www.mehr-schulferien.de?style=flat-square&logo=github) - Phoenix web application with rigorous test quality standards
 - **[trifle_stats](scenarios/libraries-frameworks/trifle-io_trifle_stats/README.md)** ![Stars](https://img.shields.io/github/stars/trifle-io/trifle_stats?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/trifle-io/trifle_stats?style=flat-square) - First Elixir example - Multi-database time-series library
 
 **Kotlin**
@@ -186,6 +192,7 @@ A curated collection of high-quality `CLAUDE.md` files from leading open-source 
 
 **Lua**
 - **[claudecode.nvim](scenarios/developer-tooling/coder_claudecode.nvim/README.md)** ![Stars](https://img.shields.io/github/stars/coder/claudecode.nvim?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/coder/claudecode.nvim?style=flat-square) - Claude Code Neovim IDE Extension
+- **[CodeCompanion.nvim](scenarios/developer-tooling/olimorris_codecompanion.nvim/README.md)** ![Stars](https://img.shields.io/github/stars/olimorris/codecompanion.nvim?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/olimorris/codecompanion.nvim?style=flat-square) - LLM-powered Neovim coding assistant
 
 **Node.js (C++)**
 - **[HWP](scenarios/developer-tooling/mcollina_hwp/README.md)** ![Stars](https://img.shields.io/github/stars/mcollina/hwp?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/mcollina/hwp?style=flat-square) - Node.js HTTP benchmarking
@@ -207,6 +214,9 @@ A curated collection of high-quality `CLAUDE.md` files from leading open-source 
 
 **Markdown/Documentation**
 - **[Tasker Systems Book](scenarios/project-handoffs/tasker-systems_book/analysis.md)** ![Stars](https://img.shields.io/github/stars/tasker-systems/book?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/tasker-systems/book?style=flat-square) - Narrative-driven technical documentation
+
+**Svelte**
+- **[Microfolio](scenarios/getting-started/aker-dev_microfolio/README.md)** ![Stars](https://img.shields.io/github/stars/aker-dev/microfolio?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/aker-dev/microfolio?style=flat-square) - Static portfolio generator with SvelteKit 2
 
 </details>
 
@@ -231,10 +241,11 @@ A curated collection of high-quality `CLAUDE.md` files from leading open-source 
 </details>
 
 <details>
-<summary><strong>🏗️ Infrastructure Projects</strong> (6 examples)</summary>
+<summary><strong>🏗️ Infrastructure Projects</strong> (7 examples)</summary>
 
 - **[Breenix OS](scenarios/infrastructure-projects/ryanbreen_breenix/README.md)** ![Stars](https://img.shields.io/github/stars/ryanbreen/breenix?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/ryanbreen/breenix?style=flat-square) - Rust kernel development with rigorous engineering
 - **[Cloudflare Workerd](scenarios/infrastructure-projects/cloudflare_workerd/README.md)** ![Stars](https://img.shields.io/github/stars/cloudflare/workerd?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/cloudflare/workerd?style=flat-square) - JavaScript runtime for Cloudflare Workers
+- **[Dymension Hub](scenarios/infrastructure-projects/dymensionxyz_dymension/README.md)** ![Stars](https://img.shields.io/github/stars/dymensionxyz/dymension?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/dymensionxyz/dymension?style=flat-square) - Cosmos SDK settlement layer for modular rollups
 - **[TrailOfBits Algo](scenarios/infrastructure-projects/trailofbits_algo/analysis.md)** ![Stars](https://img.shields.io/github/stars/trailofbits/algo?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/trailofbits/algo?style=flat-square) - Security-first VPN server setup
 - **[Ansible MCP Server](scenarios/infrastructure-projects/washyu_ansible-mcp-server/README.md)** ![Stars](https://img.shields.io/github/stars/washyu/ansible-mcp-server?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/washyu/ansible-mcp-server?style=flat-square) - Infrastructure automation with MCP
 - **[Sentry](scenarios/complex-projects/getsentry_sentry/README.md)** ![Stars](https://img.shields.io/github/stars/getsentry/sentry?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/getsentry/sentry?style=flat-square) - Multi-language error tracking platform
@@ -269,11 +280,12 @@ A curated collection of high-quality `CLAUDE.md` files from leading open-source 
 </details>
 
 <details>
-<summary><strong>🚀 Getting Started</strong> (5 examples)</summary>
+<summary><strong>🚀 Getting Started</strong> (6 examples)</summary>
 
 - **[Anthropic Quickstarts](scenarios/getting-started/anthropics_anthropic-quickstarts/README.md)** ![Stars](https://img.shields.io/github/stars/anthropics/anthropic-quickstarts?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/anthropics/anthropic-quickstarts?style=flat-square) - Official Anthropic quickstart examples
 - **[Ethereum.org Website](scenarios/getting-started/ethereum_ethereum-org-website/README.md)** ![Stars](https://img.shields.io/github/stars/ethereum/ethereum-org-website?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/ethereum/ethereum-org-website?style=flat-square) - Official Ethereum community website
 - **[KleverConnect Starter](scenarios/getting-started/klever-hub_kleverconnect-starter/README.md)** ![Stars](https://img.shields.io/github/stars/klever-hub/kleverconnect-starter?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/klever-hub/kleverconnect-starter?style=flat-square) - Web3 React + Vite starter kit
+- **[Microfolio](scenarios/getting-started/aker-dev_microfolio/README.md)** ![Stars](https://img.shields.io/github/stars/aker-dev/microfolio?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/aker-dev/microfolio?style=flat-square) - Static portfolio generator with SvelteKit 2
 - **[Dotfiles](scenarios/getting-started/obra_dotfiles/README.md)** ![Stars](https://img.shields.io/github/stars/obra/dotfiles?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/obra/dotfiles?style=flat-square) - Personal development environment configuration
 - **[Weaviate Docs](scenarios/getting-started/weaviate_docs/README.md)** ![Stars](https://img.shields.io/github/stars/weaviate/docs?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/weaviate/docs?style=flat-square) - Documentation for Weaviate Database
 
@@ -394,6 +406,16 @@ Multi-service applications with sophisticated architectures and enterprise-scale
   - Dual SQLite database management for NativePHP/Electron desktop app
   - Comprehensive service architecture with Vue 3 + Laravel 12
 
+- **[mehr-schulferien.de](scenarios/complex-projects/mehr-schulferien-de_www.mehr-schulferien.de/README.md)** ![Stars](https://img.shields.io/github/stars/mehr-schulferien-de/www.mehr-schulferien.de?style=flat-square&logo=github) ![Activity](https://img.shields.io/github/last-commit/mehr-schulferien-de/www.mehr-schulferien.de?style=flat-square) - German school vacation Phoenix/Elixir application
+  - Automated code quality enforcement via Claude Code hooks
+  - Rigorous test quality standards with measurable criteria
+  - Feature maintenance mode documentation with re-enablement steps
+
+- **[BEDROT Data Ecosystem](scenarios/complex-projects/blakedemarest_bedrot-data-ecosystem/README.md)** ![Stars](https://img.shields.io/github/stars/blakedemarest/bedrot-data-ecosystem?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/blakedemarest/bedrot-data-ecosystem?style=flat-square) ![Activity](https://img.shields.io/github/last-commit/blakedemarest/bedrot-data-ecosystem?style=flat-square) - Music industry analytics data pipeline ecosystem
+  - Multi-zone ETL architecture with six data processing stages
+  - Semi-manual authentication design philosophy for 2FA compliance
+  - Service-specific cookie lifecycle management and error severity classification
+
 ### 🛠️ Developer Tooling
 CLI tools, build systems, and development utilities with focus on commands and configuration.
 
@@ -431,6 +453,16 @@ CLI tools, build systems, and development utilities with focus on commands and c
   - Comprehensive monorepo patterns
   - Edge computing development workflows
   - Testing and deployment strategies
+
+- **[CodeCompanion.nvim](scenarios/developer-tooling/olimorris_codecompanion.nvim/README.md)** ![Stars](https://img.shields.io/github/stars/olimorris/codecompanion.nvim?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/olimorris/codecompanion.nvim?style=flat-square) ![Activity](https://img.shields.io/github/last-commit/olimorris/codecompanion.nvim?style=flat-square) - LLM-powered Neovim coding assistant
+  - Four distinct interaction modes (Chat, Inline, Cmd, Workflow)
+  - Multi-provider adapter system with HTTP and ACP adapters
+  - Lua development standards with function parameter patterns
+
+- **[Cribo](scenarios/developer-tooling/ophidiarium_cribo/README.md)** ![Stars](https://img.shields.io/github/stars/ophidiarium/cribo?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/ophidiarium/cribo?style=flat-square) ![Activity](https://img.shields.io/github/last-commit/ophidiarium/cribo?style=flat-square) - Python source bundler written in Rust
+  - Function-level code navigation guide with exact file paths
+  - Critical decision point documentation for wrapper-vs-inline classification
+  - Strict AI agent behavioral directives with deterministic output requirements
 
 - **[Kargo](scenarios/developer-tooling/cyrup-ai_kargo/README.md)** ![Stars](https://img.shields.io/github/stars/cyrup-ai/kargo?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/cyrup-ai/kargo?style=flat-square) ![Activity](https://img.shields.io/github/last-commit/cyrup-ai/kargo?style=flat-square) - Knowledge graphs and information retrieval
   - Graph-based data management
@@ -595,6 +627,11 @@ Projects focused on developer onboarding and initial setup experiences.
   - Custom hook design for Web3
   - TypeScript-first blockchain development
 
+- **[Microfolio](scenarios/getting-started/aker-dev_microfolio/README.md)** ![Stars](https://img.shields.io/github/stars/aker-dev/microfolio?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/aker-dev/microfolio?style=flat-square) ![Activity](https://img.shields.io/github/last-commit/aker-dev/microfolio?style=flat-square) - Static portfolio generator with SvelteKit 2
+  - File-based content management system with Markdown and YAML frontmatter
+  - Multi-view architecture (gallery, datatable, interactive map)
+  - Environment-aware build configuration for GitHub Pages and custom domains
+
 - **[Dotfiles](scenarios/getting-started/obra_dotfiles/README.md)** ![Stars](https://img.shields.io/github/stars/obra/dotfiles?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/obra/dotfiles?style=flat-square) ![Activity](https://img.shields.io/github/last-commit/obra/dotfiles?style=flat-square) - Personal development environment configuration
   - Comprehensive collaboration guidelines for AI assistant integration
   - Personal dotfiles with extensive tool configuration patterns
@@ -617,6 +654,11 @@ Large-scale systems, runtime environments, and platform-agnostic deployment patt
   - High-performance JavaScript runtime built in Rust
   - Edge computing platform architecture
   - V8 engine integration patterns
+
+- **[Dymension Hub](scenarios/infrastructure-projects/dymensionxyz_dymension/README.md)** ![Stars](https://img.shields.io/github/stars/dymensionxyz/dymension?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/dymensionxyz/dymension?style=flat-square) ![Activity](https://img.shields.io/github/last-commit/dymensionxyz/dymension?style=flat-square) - Cosmos SDK settlement layer for modular rollups
+  - Critical blockchain constraints documentation (determinism, no panics in consensus)
+  - Deep module architecture with inter-module dependency graph
+  - Exhaustive CLI user guide covering all blockchain operations
 
 - **[TrailOfBits Algo](scenarios/infrastructure-projects/trailofbits_algo/analysis.md)** ![Stars](https://img.shields.io/github/stars/trailofbits/algo?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/trailofbits/algo?style=flat-square) ![Activity](https://img.shields.io/github/last-commit/trailofbits/algo?style=flat-square) - Security-first VPN server setup and automation
   - Comprehensive security documentation and hardening guidelines
@@ -726,6 +768,16 @@ Core concepts, APIs, usage patterns, and publication-ready development standards
   - AI pricing analysis and comparison
   - YAML-driven configuration patterns
 
+- **[ReGo](scenarios/libraries-frameworks/gemini-oss_rego/README.md)** ![Stars](https://img.shields.io/github/stars/gemini-oss/rego?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/gemini-oss/rego?style=flat-square) ![Activity](https://img.shields.io/github/last-commit/gemini-oss/rego?style=flat-square) - Unified REST API abstraction layer for enterprise services
+  - Cross-cutting concerns documentation (auth, retry, caching, rate limiting)
+  - Structured git commit message format specification
+  - Consistent API patterns across 10+ enterprise service integrations
+
+- **[viral-assemble](scenarios/libraries-frameworks/broadinstitute_viral-assemble/README.md)** ![Stars](https://img.shields.io/github/stars/broadinstitute/viral-assemble?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/broadinstitute/viral-assemble?style=flat-square) ![Activity](https://img.shields.io/github/last-commit/broadinstitute/viral-assemble?style=flat-square) - Viral genome assembly toolkit from Broad Institute
+  - Docker-centric development paradigm with container-first workflow
+  - Command registration pattern for modular assembly pipeline
+  - Testing performance budgets with slow test markers
+
 - **[msg-rs](scenarios/libraries-frameworks/chainbound_msg-rs/analysis.md)** ![Stars](https://img.shields.io/github/stars/chainbound/msg-rs?style=flat-square&logo=github) ![License](https://img.shields.io/github/license/chainbound/msg-rs?style=flat-square) ![Activity](https://img.shields.io/github/last-commit/chainbound/msg-rs?style=flat-square) - Distributed systems messaging library
   - Async-first architecture with Tokio integration
   - Trait-based extensibility for transport and authentication
@@ -829,6 +881,6 @@ Find more `CLAUDE.md` examples using these search strategies:
 
 ---
 
-**Total Examples**: 89 | **Last Updated**: January 2025 | **Maintained by**: Community Contributors
+**Total Examples**: 101 | **Last Updated**: February 2026 | **Maintained by**: Community Contributors
 
 > 🤖 This collection is maintained with assistance from Claude Code for quality analysis and curation

--- a/scenarios/complex-projects/blakedemarest_bedrot-data-ecosystem/README.md
+++ b/scenarios/complex-projects/blakedemarest_bedrot-data-ecosystem/README.md
@@ -1,0 +1,44 @@
+# Analysis: BEDROT Data Ecosystem - Music Industry Analytics Infrastructure
+
+**Category: Complex Projects**
+**Source**: [blakedemarest/bedrot-data-ecosystem](https://github.com/blakedemarest/bedrot-data-ecosystem)
+**CLAUDE.md**: [View Original](https://github.com/blakedemarest/bedrot-data-ecosystem/blob/main/CLAUDE.md)
+**License**: MIT
+**Stars**: 1
+
+## Why This Example
+
+Despite having just one star, this CLAUDE.md is a remarkably thorough document for a production data pipeline ecosystem. It covers a three-component architecture (Data Lake, Data Warehouse, Dashboard) with multi-zone ETL processing, semi-manual authentication design philosophy, service-specific implementation status tables, and detailed error resolution guides. It demonstrates how a CLAUDE.md can serve as both a development guide and an operations manual for a complex data engineering system.
+
+### Key Features That Make This Exemplary
+
+### 1. Multi-Zone Data Lake Architecture
+The document describes a six-zone data pipeline: Landing (raw ingestion), Raw (validated immutable copies), Staging (cleaned and transformed), Curated (business-ready), Archive (7+ year retention), and Automated Cronjob (orchestration). Each zone has a clear purpose and data flow direction, providing a complete mental model of the ETL process.
+
+### 2. Semi-Manual Authentication Philosophy
+A dedicated section explains the deliberate choice of semi-manual authentication for 2FA compliance and security. This is rare and valuable because it reframes what might appear as a limitation into a principled design decision, and explicitly tells AI assistants how to interpret authentication failures: "This is EXPECTED behavior" and "Not a critical error."
+
+### 3. Service Implementation Status Matrix
+A comprehensive table tracks each data source (Spotify, TikTok, DistroKid, Linktree, MetaAds, etc.) with columns for extractor status, cleaner status, priority level, and critical notes. This gives an AI assistant immediate visibility into what is built, what is missing, and what needs attention.
+
+### 4. Critical Data Caveat Documentation
+The document includes a prominently marked warning about Spotify stream double-counting between two data sources (`tidy_daily_streams.csv` and `spotify_audience_curated_*.csv`). This kind of domain-specific data quality caveat prevents AI assistants from making costly analytical mistakes.
+
+### 5. Cookie Authentication Lifecycle Table
+Service-specific cookie expiration times, refresh intervals, authentication strategies, and 2FA requirements are documented in a structured table. This operational knowledge is critical for maintaining the pipeline and enables an AI assistant to diagnose authentication issues without guesswork.
+
+### 6. Error Resolution Guide with Severity Classification
+Common error patterns are mapped to likely causes, resolutions, and severity levels (Low for cookie/auth issues, High for system issues, Medium for data issues). This structured troubleshooting guide enables AI assistants to provide appropriate responses based on error severity.
+
+## Key Takeaways
+
+1. **Document Design Philosophy, Not Just Implementation** - Explaining why a system uses semi-manual authentication (compliance, security) prevents AI assistants from "fixing" what is actually an intentional design decision.
+2. **Include Data Quality Caveats** - For data-intensive projects, documenting known data overlap or double-counting risks in the CLAUDE.md prevents AI assistants from producing incorrect analyses.
+3. **Classify Errors by Severity** - Providing a severity framework for common errors helps AI assistants prioritize responses and avoid escalating normal operational events as critical failures.
+
+## Attribution
+
+- **Repository**: [blakedemarest/bedrot-data-ecosystem](https://github.com/blakedemarest/bedrot-data-ecosystem)
+- **Original CLAUDE.md**: [Direct Link](https://github.com/blakedemarest/bedrot-data-ecosystem/blob/main/CLAUDE.md)
+- **License**: MIT
+- **Creator**: Blake Demarest

--- a/scenarios/complex-projects/mehr-schulferien-de_www.mehr-schulferien.de/README.md
+++ b/scenarios/complex-projects/mehr-schulferien-de_www.mehr-schulferien.de/README.md
@@ -1,0 +1,44 @@
+# Analysis: mehr-schulferien.de - German School Vacation Web Application
+
+**Category: Complex Projects**
+**Source**: [mehr-schulferien-de/www.mehr-schulferien.de](https://github.com/mehr-schulferien-de/www.mehr-schulferien.de)
+**CLAUDE.md**: [View Original](https://github.com/mehr-schulferien-de/www.mehr-schulferien.de/blob/master/CLAUDE.md)
+**License**: Not specified
+**Stars**: 29
+
+## Why This Example
+
+This CLAUDE.md is an outstanding example of documenting a production Phoenix/Elixir web application with exceptional attention to test quality standards, code quality enforcement through hooks, and migration status tracking. It demonstrates how to maintain a living document that evolves with the project, including detailed maintenance mode documentation for temporarily disabled features.
+
+### Key Features That Make This Exemplary
+
+### 1. Automated Code Quality Enforcement via Hooks
+The document explains that Claude Code hooks automatically run `mix format`, `mix test`, and `mix compile --warnings-as-errors` after each response. This creates a feedback loop where the AI assistant's responsibilities are explicitly defined: fix test failures when UI changes break assertions, fix all warnings immediately, and verify clean test output.
+
+### 2. Rigorous Test Quality Standards
+An entire section is dedicated to defining what "clean" tests look like: no debug output (`IO.puts`, `IO.inspect`, `dbg()`), no skipped tests, no placeholder tests (`assert true`), no warnings in output, and no flaky tests. A concrete test quality checklist with exact shell commands is provided for verification before every commit.
+
+### 3. Feature Maintenance Mode Documentation
+The wiki functionality is documented as "temporarily disabled" with a precise step-by-step re-enablement guide: uncomment routes in router.ex, remove `@moduletag :skip` from 13 specific test files (all listed by path), and run verification tests. This pattern of documenting disabled features is valuable for long-lived projects.
+
+### 4. Phoenix Migration Status Tracking
+The document tracks the completed Phoenix 1.7 to 1.8 migration with specific details: View modules migrated to format-specific modules (HTML, JSON, ICS, XML), controller configuration updated, and test dependencies added. It also documents the completed migration to Phoenix verified routes with the `~p` sigil pattern.
+
+### 5. Styling Guidelines with Design System Reference
+The document specifies Tailwind CSS as the mandatory styling framework with references to shared components (`<.heading>`, `<.card>`, `<.button>`), design tokens, and specific patterns for list formatting and wiki form elements including exact CSS class strings for form inputs.
+
+### 6. Proactive Test Maintenance Protocol
+A dedicated protocol defines how to approach test issues systematically: always check test output quality first, identify all issues (not just the obvious one), fix root causes rather than symptoms, and verify fixes with multiple runs. "Red flags" requiring immediate action are listed explicitly.
+
+## Key Takeaways
+
+1. **Enforce Quality Through Hooks, Not Just Instructions** - Documenting automated quality gates (hooks that run tests and linting after each AI response) creates a more reliable feedback loop than relying on the AI assistant to remember to run checks.
+2. **Define Test Quality as a Measurable Standard** - Specifying exact criteria for clean tests (no debug output, no skipped tests, no warnings) with verification commands transforms test quality from a subjective judgment into an auditable checklist.
+3. **Document Feature States with Re-enablement Steps** - For temporarily disabled features, providing exact file paths and steps to re-enable prevents knowledge loss and makes it trivial for an AI assistant to restore functionality when needed.
+
+## Attribution
+
+- **Repository**: [mehr-schulferien-de/www.mehr-schulferien.de](https://github.com/mehr-schulferien-de/www.mehr-schulferien.de)
+- **Original CLAUDE.md**: [Direct Link](https://github.com/mehr-schulferien-de/www.mehr-schulferien.de/blob/master/CLAUDE.md)
+- **License**: Not specified
+- **Creator**: mehr-schulferien.de community

--- a/scenarios/developer-tooling/olimorris_codecompanion.nvim/README.md
+++ b/scenarios/developer-tooling/olimorris_codecompanion.nvim/README.md
@@ -1,0 +1,44 @@
+# Analysis: CodeCompanion.nvim - LLM-Powered Neovim Plugin
+
+**Category: Developer Tooling**
+**Source**: [olimorris/codecompanion.nvim](https://github.com/olimorris/codecompanion.nvim)
+**CLAUDE.md**: [View Original](https://github.com/olimorris/codecompanion.nvim/blob/main/CLAUDE.md)
+**License**: Apache-2.0
+**Stars**: 6,092
+
+## Why This Example
+
+This CLAUDE.md is a masterclass in documenting a plugin architecture for AI-assisted development. It meticulously maps out the interaction modes, adapter system, tool execution pipeline, and slash command framework of a Neovim plugin that integrates multiple LLM providers. The document demonstrates how to communicate complex plugin architecture to an AI assistant with precision and clarity.
+
+### Key Features That Make This Exemplary
+
+### 1. Interaction Mode Architecture
+The document clearly separates and describes four distinct interaction modes: Chat (buffer-based with tools and slash commands), Inline (direct code transformation), Cmd (lightweight query-response), and Workflow (multi-stage prompts with subscribers). This taxonomy gives an AI assistant a complete mental model of the plugin's capabilities.
+
+### 2. Adapter System Documentation
+The CLAUDE.md catalogs both HTTP adapters (Anthropic, OpenAI, Copilot, Ollama, Gemini, and many more) and ACP adapters (Claude Code, Auggie CLI, Codex, Gemini CLI) in a structured format. This makes it straightforward for an AI assistant to add new provider integrations following the established patterns.
+
+### 3. Message Flow and Tool Execution Pipeline
+A clear data flow diagram shows the path from user input through interactions and adapters to the LLM, and back through parsers and tools to the chat buffer. The tool execution pipeline is documented step-by-step: LLM returns tool calls, orchestrator extracts and validates, tools execute, results sent back. This enables AI assistants to debug issues at any point in the pipeline.
+
+### 4. Lua Development Standards with Function Parameter Patterns
+The document specifies a preferred function parameter style using table arguments rather than positional parameters, with concrete before/after examples. This opinionated guidance ensures consistent code generation across the entire codebase.
+
+### 5. Comprehensive File Organization Map
+Key files are enumerated with their purposes: plugin entry point, main module, configuration management, type definitions, HTTP client, and a full utilities breakdown. Combined with the naming conventions (snake_case for files/functions, PascalCase for classes, underscore prefix for private functions), this gives an AI assistant everything needed to navigate and extend the codebase.
+
+### 6. Concise Behavioral Directive
+The document closes with a clear behavioral instruction: "Do what has been asked; nothing more, nothing less" with explicit prohibitions against creating unnecessary files or documentation. This focused directive prevents AI assistants from overstepping their scope.
+
+## Key Takeaways
+
+1. **Document Plugin Architecture as Interaction Modes** - For plugin systems, organizing documentation around user-facing interaction modes (chat, inline, command, workflow) provides a more intuitive mental model than describing internal implementation details alone.
+2. **Show Data Flow Diagrams in Text** - Simple text-based flow diagrams (User Input -> Interaction -> Adapter -> LLM) are highly effective at communicating architecture to AI assistants and cost almost nothing to maintain.
+3. **Specify Code Style with Concrete Examples** - Showing preferred patterns (table parameters vs positional parameters) with actual code snippets eliminates ambiguity and produces more consistent AI-generated code.
+
+## Attribution
+
+- **Repository**: [olimorris/codecompanion.nvim](https://github.com/olimorris/codecompanion.nvim)
+- **Original CLAUDE.md**: [Direct Link](https://github.com/olimorris/codecompanion.nvim/blob/main/CLAUDE.md)
+- **License**: Apache-2.0
+- **Creator**: Oli Morris

--- a/scenarios/developer-tooling/ophidiarium_cribo/README.md
+++ b/scenarios/developer-tooling/ophidiarium_cribo/README.md
@@ -1,0 +1,44 @@
+# Analysis: Cribo - Python Source Bundler in Rust
+
+**Category: Developer Tooling**
+**Source**: [ophidiarium/cribo](https://github.com/ophidiarium/cribo)
+**CLAUDE.md**: [View Original](https://github.com/ophidiarium/cribo/blob/main/CLAUDE.md)
+**License**: NOASSERTION
+**Stars**: 4
+
+## Why This Example
+
+Despite its small star count, this CLAUDE.md is one of the most technically detailed and AI-engineering-focused documents in the collection. It provides an exhaustive navigation guide through a Rust codebase that bundles Python projects into single files, with precise function-level pointers, critical decision point documentation, debugging commands, and an unusually rigorous set of directives for AI agent behavior. This is a textbook example of optimizing a CLAUDE.md for AI-assisted development.
+
+### Key Features That Make This Exemplary
+
+### 1. Function-Level Navigation Guide
+The document provides exact file paths and function names for every critical code path: `BundleOrchestrator::bundle()` as entry point, `PhaseOrchestrator::bundle()` for 9-phase bundling, `classify_modules()` for the wrapper-vs-inline decision, and more. This level of precision eliminates the need for AI assistants to search through the codebase.
+
+### 2. Critical Decision Point Documentation
+Three key decision points are documented with their exact logic: the wrapper-vs-inline module classification, circular dependency classification (with five distinct types), and global variable lifting. Each includes the relevant code paths, the conditions that trigger each branch, and the implications. This is invaluable for understanding the bundler's behavior.
+
+### 3. Debugging Command Reference
+The document includes targeted debug commands using `RUST_LOG` environment variables with grep filters for specific concerns: module classification decisions, import transformation traces, circular dependency detection, and tree-shaking decisions. This transforms debugging from exploration into targeted investigation.
+
+### 4. Mandatory Git Flow Template
+A structured checklist template covers pre-work baseline verification, feature branch creation with test and clippy validation, and PR creation with comprehensive descriptions. The emphasis on `git worktree` over `git checkout` to preserve uncommitted changes shows deep operational awareness.
+
+### 5. Strict AI Agent Behavioral Directives
+The document includes remarkably specific directives: enforce `.clippy.toml` disallowed types, never use `#[allow]` annotations as fixes, never hardcode test values in production code, remove dead code immediately rather than deprecating, and always select technically optimal solutions without factoring in human constraints. These transform the CLAUDE.md into an enforceable policy document.
+
+### 6. Deterministic Output Requirements
+A dedicated section explains why deterministic, reproducible output is critical (avoiding unnecessary redeployments, simplifying diff inspection) and links this to specific implementation rules: sort imports, use `IndexMap`/`IndexSet` instead of `HashMap`/`HashSet`, and apply consistent formatting regardless of input order.
+
+## Key Takeaways
+
+1. **Provide Function-Level Code Pointers** - For complex codebases, documenting exact file paths and function names for critical paths saves AI assistants enormous search time and reduces the chance of modifying the wrong code.
+2. **Document Decision Points, Not Just Architecture** - Explaining the specific conditions that trigger different code paths (wrapper vs inline, circular dependency types) gives AI assistants the context needed to make correct modifications.
+3. **Encode Engineering Policies as Directives** - Explicit prohibitions (no `#[allow]` annotations, no hardcoded test values, no deprecation markers) are more effective than general guidelines because they give AI assistants clear boundaries to enforce.
+
+## Attribution
+
+- **Repository**: [ophidiarium/cribo](https://github.com/ophidiarium/cribo)
+- **Original CLAUDE.md**: [Direct Link](https://github.com/ophidiarium/cribo/blob/main/CLAUDE.md)
+- **License**: NOASSERTION
+- **Organization**: Ophidiarium

--- a/scenarios/getting-started/aker-dev_microfolio/README.md
+++ b/scenarios/getting-started/aker-dev_microfolio/README.md
@@ -1,0 +1,44 @@
+# Analysis: Microfolio - Static Portfolio Generator
+
+**Category: Getting Started**
+**Source**: [aker-dev/microfolio](https://github.com/aker-dev/microfolio)
+**CLAUDE.md**: [View Original](https://github.com/aker-dev/microfolio/blob/main/CLAUDE.md)
+**License**: MIT
+**Stars**: 127
+
+## Why This Example
+
+This CLAUDE.md demonstrates an ideal onboarding document for a SvelteKit-based static site generator. It covers the file-based content management system, data loading patterns, build and deployment configuration, and project metadata schema in a well-organized format. The document makes it straightforward for an AI assistant to understand how content flows from Markdown files through server-side processing to the final static site.
+
+### Key Features That Make This Exemplary
+
+### 1. File-Based Content System Documentation
+The document clearly describes the content structure: projects live in `/content/projects/{project-name}/` with `index.md` for metadata, `thumbnail.jpg` for thumbnails, and subdirectories for images, documents, and videos. This filesystem-as-CMS pattern is documented precisely enough for an AI assistant to create new content correctly.
+
+### 2. Data Loading Pattern Explanation
+The server-side data loading pipeline is documented step by step: `+page.server.js` files read Markdown with `fs/promises`, parse YAML frontmatter with the `yaml` library, and convert Markdown to HTML using `marked`. This chain of transformations is exactly what an AI assistant needs to understand when debugging content rendering issues.
+
+### 3. Project Metadata Schema with YAML Example
+A complete YAML frontmatter schema is provided with all supported fields: title, date, location, coordinates (for map display), description, type, tags, authors with roles, and the `featured` flag for homepage display. This schema reference enables AI assistants to create properly structured content without trial and error.
+
+### 4. Environment-Aware Build Configuration
+The document explains how the base path differs between development and production (GitHub Pages uses `/microfolio`, custom domains use no base path), controlled by the `CUSTOM_DOMAIN` environment variable. This deployment-aware configuration documentation prevents common build issues.
+
+### 5. Multi-View Architecture
+The routing structure is documented with four distinct views: homepage with featured projects, gallery view, datatable view with filtering, and an interactive Leaflet map view. Each route is mapped to its URL path, giving AI assistants a complete picture of the application's user-facing surface.
+
+### 6. CLI Tool Integration
+The document mentions a Homebrew-installable CLI tool (`microfolio new`, `microfolio dev`, `microfolio build`) that wraps the development commands. This bridges the gap between the package manager commands and a user-friendly CLI interface.
+
+## Key Takeaways
+
+1. **Document Content Schemas Explicitly** - For content-driven sites, providing the exact YAML/frontmatter schema with all supported fields eliminates guesswork and enables AI assistants to create correctly structured content on the first attempt.
+2. **Explain the Data Loading Pipeline** - Documenting how content moves from filesystem through parsing libraries to rendered HTML gives AI assistants the context needed to debug issues at any point in the chain.
+3. **Address Environment Differences** - Explicitly documenting how build configuration varies between development, production, and custom domain deployments prevents an entire class of "works locally, breaks in production" issues.
+
+## Attribution
+
+- **Repository**: [aker-dev/microfolio](https://github.com/aker-dev/microfolio)
+- **Original CLAUDE.md**: [Direct Link](https://github.com/aker-dev/microfolio/blob/main/CLAUDE.md)
+- **License**: MIT
+- **Creator**: AKER

--- a/scenarios/infrastructure-projects/dymensionxyz_dymension/README.md
+++ b/scenarios/infrastructure-projects/dymensionxyz_dymension/README.md
@@ -1,0 +1,44 @@
+# Analysis: Dymension Hub - Cosmos SDK Settlement Layer
+
+**Category: Infrastructure Projects**
+**Source**: [dymensionxyz/dymension](https://github.com/dymensionxyz/dymension)
+**CLAUDE.md**: [View Original](https://github.com/dymensionxyz/dymension/blob/main/CLAUDE.md)
+**License**: NOASSERTION
+**Stars**: 391
+
+## Why This Example
+
+This is one of the most comprehensive CLAUDE.md files in the blockchain infrastructure space. It documents the Dymension Hub, a Cosmos SDK-based settlement layer, with extraordinary depth covering module architecture, inter-module dependencies, a complete CLI user guide, and critical blockchain-specific constraints like determinism requirements and single-threaded execution. The document serves as both a development guide and an operational reference.
+
+### Key Features That Make This Exemplary
+
+### 1. Critical Blockchain Facts Section
+The document opens with essential "FACTS" about Cosmos SDK behavior: single-threaded execution, atomic transaction rollback, and the requirement that BeginBlocker/EndBlocker functions must never panic to avoid chain halts. These constraints are critical for any AI assistant generating code for this project.
+
+### 2. Deep Module Architecture Documentation
+The CLAUDE.md maps out the entire module hierarchy under `x/` with clear categorization into Core Modules (rollapp, sequencer, lightclient, delayedack, eibc), Economic Modules (iro, incentives, sponsorship, streamer, lockup), and Utility Modules (denommetadata, dymns, gamm). Each module includes a brief description of its responsibility and key behaviors.
+
+### 3. Inter-Module Dependency Graph
+A dedicated section documents key cross-module dependencies (e.g., `rollapp` depends on `sequencer` for validation, `delayedack` depends on `rollapp` for state finalization). This is invaluable for an AI assistant that needs to understand the impact of changes across module boundaries.
+
+### 4. Exhaustive CLI User Guide
+The document includes a remarkably complete CLI reference for the `dymd` binary covering key management, querying blockchain state, creating transactions, governance, IBC operations, snapshot management, and debug tools. This transforms the CLAUDE.md into a self-contained operational manual.
+
+### 5. Code Style Guidelines with Anti-Patterns
+The code style section explicitly states to "NEVER comment the WHAT" and "ONLY add comments to explain WHY," with concrete good and bad examples. This opinionated guidance prevents AI assistants from generating verbose, redundant comments.
+
+### 6. CI Tool Usage Efficiency Guidance
+The document advises running tools "only as needed" to avoid unnecessary work, specifying which tools to run based on which files were modified. This practical optimization guidance is rare and highly useful for AI-assisted development.
+
+## Key Takeaways
+
+1. **State Domain-Specific Constraints Prominently** - Blockchain projects have unique constraints (determinism, no panics in consensus code). Placing these at the top of CLAUDE.md prevents AI assistants from generating code that could cause chain halts or consensus failures.
+2. **Map Module Dependencies Explicitly** - In modular architectures, documenting which modules depend on which others helps AI assistants understand the blast radius of changes and write properly integrated code.
+3. **Include Operational References** - A comprehensive CLI guide within the CLAUDE.md means AI assistants can help with operational tasks without needing to consult external documentation, making the file a single source of truth.
+
+## Attribution
+
+- **Repository**: [dymensionxyz/dymension](https://github.com/dymensionxyz/dymension)
+- **Original CLAUDE.md**: [Direct Link](https://github.com/dymensionxyz/dymension/blob/main/CLAUDE.md)
+- **License**: NOASSERTION
+- **Organization**: Dymension

--- a/scenarios/libraries-frameworks/broadinstitute_viral-assemble/README.md
+++ b/scenarios/libraries-frameworks/broadinstitute_viral-assemble/README.md
@@ -1,0 +1,44 @@
+# Analysis: viral-assemble - Viral Genome Assembly Toolkit
+
+**Category: Libraries & Frameworks**
+**Source**: [broadinstitute/viral-assemble](https://github.com/broadinstitute/viral-assemble)
+**CLAUDE.md**: [View Original](https://github.com/broadinstitute/viral-assemble/blob/main/CLAUDE.md)
+**License**: NOASSERTION
+**Stars**: 10
+
+## Why This Example
+
+This CLAUDE.md documents a scientific computing toolkit for viral genome assembly from the Broad Institute, one of the world's leading genomics research institutions. It demonstrates how to onboard an AI assistant to a docker-centric bioinformatics pipeline with modular command registration, conda dependency management, and a layered testing strategy. The document is concise yet comprehensive, covering the full development lifecycle from container setup to CI/CD.
+
+### Key Features That Make This Exemplary
+
+### 1. Docker-Centric Development Paradigm
+The document explicitly states that the "development paradigm is intentionally docker-centric" and provides the exact `docker run` command with volume mounts to develop locally inside the viral-core container. This upfront declaration prevents AI assistants from suggesting non-containerized workflows that would fail.
+
+### 2. Command Registration Pattern Documentation
+The architecture section explains the command registration system: commands are registered via `__commands__` tuples, each with a parser function and main function connected via `util.cmd.attach_main()`. This pattern documentation enables AI assistants to add new assembly subcommands correctly.
+
+### 3. Assembly Pipeline Flow
+The typical assembly workflow is documented as a five-step pipeline: trim_rmdup_subsamp (clean reads), assemble_spades (de novo assembly), order_and_orient (scaffold against reference), impute_from_reference (fill gaps), and refine_assembly (iterative improvement). This pipeline overview gives AI assistants the scientific context for understanding how individual commands fit together.
+
+### 4. Testing Performance Constraints
+The document includes a specific testing guideline: "New tests should add no more than ~20-30 seconds to testing time" with slow tests requiring a `@pytest.mark.slow` marker. This practical constraint prevents AI assistants from generating computationally expensive tests that slow down the development cycle.
+
+### 5. Error Handling Taxonomy
+Three distinct error types are documented: `DenovoAssemblyError` for assembly failures, `IncompleteAssemblyError` for quality threshold failures, and `PoorAssemblyError` for quality criteria failures. This error taxonomy helps AI assistants implement proper error handling in new assembly code.
+
+### 6. Layered Dependency Architecture
+The document maps the dependency relationship with viral-core, listing imported utilities (cmd, file, misc, read_utils) and tool wrappers (picard, samtools, gatk, novoalign, trimmomatic, minimap2). This dependency inventory prevents AI assistants from duplicating functionality already available in the core library.
+
+## Key Takeaways
+
+1. **Declare the Development Paradigm Early** - When a project uses a non-standard development approach (docker-centric, container-first), stating this upfront prevents AI assistants from suggesting incompatible workflows.
+2. **Document Testing Performance Budgets** - Setting explicit time budgets for new tests ensures AI assistants generate efficient tests that maintain fast feedback loops, especially important in scientific computing where test data can be large.
+3. **Map the Dependency Hierarchy** - For projects that layer on top of a core library, documenting which utilities and tools are inherited from the parent project prevents duplication and ensures consistent usage patterns.
+
+## Attribution
+
+- **Repository**: [broadinstitute/viral-assemble](https://github.com/broadinstitute/viral-assemble)
+- **Original CLAUDE.md**: [Direct Link](https://github.com/broadinstitute/viral-assemble/blob/main/CLAUDE.md)
+- **License**: NOASSERTION
+- **Organization**: Broad Institute of MIT and Harvard

--- a/scenarios/libraries-frameworks/gemini-oss_rego/README.md
+++ b/scenarios/libraries-frameworks/gemini-oss_rego/README.md
@@ -1,0 +1,38 @@
+# Analysis: Regolith (ReGo) - Unified REST API Abstraction Layer
+
+**Category: Libraries & Frameworks**
+**Source**: [gemini-oss/rego](https://github.com/gemini-oss/rego)
+**CLAUDE.md**: [View Original](https://github.com/gemini-oss/rego/blob/main/CLAUDE.md)
+**License**: Apache-2.0
+**Stars**: 12
+
+## Why This Example
+
+This CLAUDE.md stands out for documenting a unified abstraction layer across more than ten enterprise REST APIs (Google Workspace, Okta, Jamf, Active Directory, Slack, and more). It provides an exceptionally thorough project overview that communicates both the architectural vision and the practical development workflow, making it a strong reference for any multi-service integration library.
+
+### Key Features That Make This Exemplary
+
+### 1. Comprehensive Feature Inventory
+The document opens with a precise enumeration of cross-cutting concerns handled by the library: OAuth2/JWT/API key/LDAP authentication management, automatic retry with exponential backoff, encrypted file-based caching with configurable TTL, per-service rate limiting, generic pagination, and progress tracking. This gives an AI assistant immediate understanding of the library's scope.
+
+### 2. Structured Git Commit Message Format
+The CLAUDE.md mandates a structured "release notes" format for all commit messages, going beyond a simple "use conventional commits" instruction. This level of specificity helps AI assistants generate properly formatted commits that align with the project's established conventions.
+
+### 3. Well-Organized Development Commands
+Build, test, formatting, and version control commands are presented with clear Makefile targets and direct Go commands side by side. Specific test invocations for individual packages (`go test -v ./pkg/google/...`) and named tests (`go test -v -run TestFunctionName`) are documented, enabling precise test-driven development.
+
+### 4. Cross-Service Consistent API Patterns
+The project overview emphasizes method chaining for complex queries, concurrent operations support, and generic pagination handling across all services. Documenting these patterns in the CLAUDE.md ensures an AI assistant understands the design philosophy before writing new service integrations.
+
+## Key Takeaways
+
+1. **Document Cross-Cutting Concerns Up Front** - When a library handles multiple services, listing shared capabilities (auth, retry, caching, rate limiting) at the top gives AI assistants the architectural context needed to write consistent code across all service clients.
+2. **Specify Commit Message Formats Explicitly** - Rather than referencing an external convention, embedding the exact commit format in the CLAUDE.md ensures AI assistants generate properly structured messages without additional lookups.
+3. **Provide Granular Test Commands** - Including commands for running all tests, package-specific tests, named tests, and coverage reports empowers an AI assistant to validate changes at the appropriate scope.
+
+## Attribution
+
+- **Repository**: [gemini-oss/rego](https://github.com/gemini-oss/rego)
+- **Original CLAUDE.md**: [Direct Link](https://github.com/gemini-oss/rego/blob/main/CLAUDE.md)
+- **License**: Apache-2.0
+- **Organization**: Gemini OSS


### PR DESCRIPTION
  Closes #46
  Closes #49
  Closes #51
  Closes #53
  Closes #54
  Closes #76
  Closes #77
  Closes #78
Add examples covering 3 new languages (Lua, Elixir, Svelte) and boosting underrepresented categories (getting-started, infrastructure).

New examples:
- gemini-oss/rego (Go, libraries-frameworks)
- dymensionxyz/dymension (Go, infrastructure-projects)
- olimorris/codecompanion.nvim (Lua, developer-tooling)
- ophidiarium/cribo (Rust, developer-tooling)
- mehr-schulferien-de/www.mehr-schulferien.de (Elixir, complex-projects)
- blakedemarest/bedrot-data-ecosystem (Python, complex-projects)
- aker-dev/microfolio (Svelte, getting-started)
- broadinstitute/viral-assemble (Python, libraries-frameworks)

Total examples: 89 -> 97