### PR TITLE
Add NotFair (Google Ads MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,6 +870,7 @@ Documentation focused on project state, blocking issues, and transition planning
 |------|-------------|---------|
 | [claude-brain](https://github.com/toroleapinc/claude-brain) | Sync CLAUDE.md and Claude Code configuration across machines via git hooks | MIT |
 | [sourcebook](https://github.com/maroondlabs/sourcebook) | Generate CLAUDE.md from codebase conventions, constraints, and git forensics | BSL-1.1 |
+| [NotFair](https://notfair.co) | Google Ads MCP server for AI agents. Diagnose campaigns, recommend optimizations, execute approved changes via the Google Ads API. |
 
 ## Quality Standards
 

--- a/README.md
+++ b/README.md
@@ -870,7 +870,7 @@ Documentation focused on project state, blocking issues, and transition planning
 |------|-------------|---------|
 | [claude-brain](https://github.com/toroleapinc/claude-brain) | Sync CLAUDE.md and Claude Code configuration across machines via git hooks | MIT |
 | [sourcebook](https://github.com/maroondlabs/sourcebook) | Generate CLAUDE.md from codebase conventions, constraints, and git forensics | BSL-1.1 |
-| [NotFair](https://notfair.co) | Google Ads MCP server for AI agents. Diagnose campaigns, recommend optimizations, execute approved changes via the Google Ads API. |
+| [NotFair](https://notfair.co) | Google Ads MCP server for AI agents. Diagnose campaigns, recommend optimizations, execute approved changes via the Google Ads API. | MIT |
 
 ## Quality Standards
 


### PR DESCRIPTION
Adding NotFair under Tools & Ecosystem. It's a Google Ads MCP server that lets Claude and other AI agents diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API.

Source: github.com/nowork-studio/toprank
Registry: io.github.nowork-studio/notfair (active in the official MCP registry)
Endpoint: streamable-http at notfair.co/api/mcp/google_ads

Free tier available. Happy to adjust the format if you'd prefer.