### PR TITLE
Add claude-code-pro-pack, cc-audit, and gemma-coder to Tools & Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,6 +870,9 @@ Documentation focused on project state, blocking issues, and transition planning
 |------|-------------|---------|
 | [claude-brain](https://github.com/toroleapinc/claude-brain) | Sync CLAUDE.md and Claude Code configuration across machines via git hooks | MIT |
 | [sourcebook](https://github.com/maroondlabs/sourcebook) | Generate CLAUDE.md from codebase conventions, constraints, and git forensics | BSL-1.1 |
+| [claude-code-pro-pack](https://github.com/sisyphusse1-ops/claude-code-pro-pack) | Drop-in 12-rule `CLAUDE.md` + `AGENTS.md` baseline with PRD generator, browser-skill-graduation, and 5 example skills (~700 tokens total) | MIT |
+| [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) | Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline; flags leaked secrets and compliance-cliff length. Zero dependencies, CI-ready | MIT |
+| [gemma-coder](https://github.com/sisyphusse1-ops/gemma-coder) | Single-file agentic coding CLI that loads `CLAUDE.md` / `AGENTS.md` as the rulebook for Gemma 4 / Ollama / OpenRouter — demonstrates `CLAUDE.md` as a cross-model standard | MIT |
 
 ## Quality Standards
 


### PR DESCRIPTION
Resolves #100.

Adds three related tools to the **Tools & Ecosystem** section:

- **[claude-code-pro-pack](https://github.com/sisyphusse1-ops/claude-code-pro-pack)** — drop-in 12-rule CLAUDE.md + AGENTS.md baseline with PRD generator, browser-skill-graduation workflow, and 5 example skills. ~700 tokens total.
- **[cc-audit](https://github.com/sisyphusse1-ops/cc-audit)** — single-file Python linter that scores any CLAUDE.md / AGENTS.md against a 12-rule baseline. Flags leaked secrets (PAT/AWS/paypal), size-cliff issues, missing project-specifics. Zero deps, CI-ready.
- **[gemma-coder](https://github.com/sisyphusse1-ops/gemma-coder)** — single-file agentic coding CLI that loads CLAUDE.md / AGENTS.md as the rulebook for Gemma 4 via Ollama or OpenRouter. Demonstrates CLAUDE.md as a cross-model standard, not just a Claude file.

All three are MIT, zero-dep or stdlib-only, and actively maintained.

Fit with existing entries: complements `claude-brain` (sync) and `sourcebook` (generation) by adding **baseline** (pro-pack), **validation** (cc-audit), and **cross-model demo** (gemma-coder) to the tool stack.