### PR TITLE
fix(docs): update site tech stack from Jekyll to Astro/Tailwind

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,36 +108,15 @@ The repository includes a browsable static site at `https://josix.github.io/awes
 
 ### Site Structure
 - **Location**: `docs/` folder (served via GitHub Pages)
-- **Technology**: Jekyll with custom dark theme
+- **Technology**: Astro with Tailwind CSS and Pagefind search
 - **Features**: Search, category filters, language filters, responsive design
 
-### Key Files
-- `docs/_config.yml`: Jekyll configuration (baseurl, title, theme settings)
-- `docs/_layouts/default.html`: Base HTML layout with header, footer, navigation
-- `docs/assets/css/style.css`: Dark-themed responsive CSS with CSS variables
-- `docs/assets/js/main.js`: Client-side search and filter functionality
-- `docs/index.html`: Main page with all examples as filterable cards
-
-### Adding New Examples to the Site
-When adding new examples to `scenarios/`, also update `docs/index.html`:
-1. Add a new `<div class="example-card">` in the appropriate category section
-2. Include required data attributes: `data-category`, `data-language`, `data-title`, `data-repo`, `data-description`
-3. Follow the existing card structure with icon, title, description, tags, and links
-
-### Site Features
-- **Search**: Real-time filtering by title, repo name, or description (Ctrl+K shortcut)
-- **Category Filters**: Filter by 6 categories (complex-projects, developer-tooling, etc.)
-- **Language Filters**: Filter by programming language (TypeScript, Python, Rust, Go, Swift, Java)
-- **Responsive Design**: Mobile-friendly layout with dark theme
-- **Direct Links**: Each card links to both the analysis page and original repository
-
 ### Local Development
-To preview the site locally:
 ```bash
 cd docs
-bundle install  # First time only
-bundle exec jekyll serve
-# Visit http://localhost:4000/awesome-claude-md/
+npm install     # First time only
+npm run dev     # Visit http://localhost:4321/
+npm run build   # Production build (also runs pagefind indexing)
 ```
 
 ## GitHub Copilot Integration


### PR DESCRIPTION
## Summary
- CLAUDE.md described a Jekyll setup but `docs/` now uses Astro with Tailwind CSS and Pagefind
- Replaces stale `bundle install` / `bundle exec jekyll serve` commands with correct `npm run dev` / `npm run build` workflow
- Removes references to non-existent Jekyll files (`_config.yml`, `_layouts/`, `assets/css/style.css`, etc.)

## Test plan
- [ ] Verify `docs/package.json` confirms Astro as the framework
- [ ] Confirm `npm run dev` starts the site at `http://localhost:4321/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)